### PR TITLE
Готовый контроллер для /state

### DIFF
--- a/server/controllers/MovementController.cc
+++ b/server/controllers/MovementController.cc
@@ -5,35 +5,57 @@
 //check
 //hello
 
-void MovementController :: getState(const drogon::HttpRequestPtr &req,
+void MovementController ::postPosition(const drogon::HttpRequestPtr &req,
     std::function<void(const drogon::HttpResponsePtr &)> &&callback){
+    
+    Json::Value jsonBody;
 
+    
     try
     {
-        // need to get full robot state
-        //for example -> make json answer message = "State controller is working!!!"
+        auto requestBody = req->getJsonObject();
 
-        Json::Value resp;
-        resp["message"] = "Movement controller is working!!!";
+        // Проверка что запрос не пустой
+        if (requestBody == nullptr) {
+            jsonBody["status"] = "error";
+            jsonBody["message"] = "Body is required";
+            auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+            response->setStatusCode(HttpStatusCode::k400BadRequest);
+            callback(response);
+            return;
+        }
 
-        auto response = drogon::HttpResponse::newHttpJsonResponse(resp);
-        response->setStatusCode(drogon::HttpStatusCode::k200OK);
+        // Проверка что пришла позиция меха
+        if (!requestBody->isMember("x") || !requestBody->isMember("y")) {
+            jsonBody["status"] = "error";
+            jsonBody["message"] = "Fields 'x' and 'y' are required";
+            auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+            response->setStatusCode(HttpStatusCode::k400BadRequest);
+            callback(response);
+            return;
+        }
 
+        // Получение позиции
+        std::string x = requestBody->get("x", "").asString();
+        std::string y = requestBody->get("y", "").asString();
+        
+        std::cout << "Received position " << x << ", " << y << std::endl;
+
+        jsonBody["status"] = "ok";
+        jsonBody["message"] = "Position received";
+        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
         callback(response);
 
-        //
     }
+
     catch(const std::exception& e)
     {
-        Json::Value err;
-        err["error"] = e.what();
-
-        auto response = drogon::HttpResponse::newHttpJsonResponse(err);
+        jsonBody["status"] = "error";
+        jsonBody["message"] = std::string("Error: ") + e.what();
+        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
         response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
-
         callback(response);
     }
-    
 
 }
 

--- a/server/controllers/MovementController.cc
+++ b/server/controllers/MovementController.cc
@@ -2,15 +2,11 @@
 #include "jsoncpp/json/json.h"
 #include <iostream>
 
-//check
-//hello
-
 void MovementController ::postPosition(const drogon::HttpRequestPtr &req,
     std::function<void(const drogon::HttpResponsePtr &)> &&callback){
     
     Json::Value jsonBody;
-
-    
+   
     try
     {
         auto requestBody = req->getJsonObject();
@@ -45,7 +41,6 @@ void MovementController ::postPosition(const drogon::HttpRequestPtr &req,
         jsonBody["message"] = "Position received";
         auto response = HttpResponse::newHttpJsonResponse(jsonBody);
         callback(response);
-
     }
 
     catch(const std::exception& e)
@@ -56,7 +51,6 @@ void MovementController ::postPosition(const drogon::HttpRequestPtr &req,
         response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
         callback(response);
     }
-
 }
 
 

--- a/server/controllers/MovementController.cc
+++ b/server/controllers/MovementController.cc
@@ -12,19 +12,10 @@ void MovementController ::postPosition(const drogon::HttpRequestPtr &req,
         auto requestBody = req->getJsonObject();
 
         // Проверка что запрос не пустой
-        if (requestBody == nullptr) {
+        if (!requestBody || !requestBody->isMember("x") || !requestBody->isMember("y")) 
+        {
             jsonBody["status"] = "error";
             jsonBody["message"] = "Body is required";
-            auto response = HttpResponse::newHttpJsonResponse(jsonBody);
-            response->setStatusCode(HttpStatusCode::k400BadRequest);
-            callback(response);
-            return;
-        }
-
-        // Проверка что пришла позиция меха
-        if (!requestBody->isMember("x") || !requestBody->isMember("y")) {
-            jsonBody["status"] = "error";
-            jsonBody["message"] = "Fields 'x' and 'y' are required";
             auto response = HttpResponse::newHttpJsonResponse(jsonBody);
             response->setStatusCode(HttpStatusCode::k400BadRequest);
             callback(response);

--- a/server/controllers/MovementController.h
+++ b/server/controllers/MovementController.h
@@ -16,7 +16,6 @@ class MovementController : public drogon::HttpController<MovementController>
       drogon::Post
     );
     
-
     METHOD_LIST_END
     
     void postPosition(const drogon::HttpRequestPtr &req,

--- a/server/controllers/MovementController.h
+++ b/server/controllers/MovementController.h
@@ -9,15 +9,16 @@ class MovementController : public drogon::HttpController<MovementController>
   public:
     METHOD_LIST_BEGIN
     
-     ADD_METHOD_TO(
-      MovementController::getState,
-      "/move",
-      drogon::Get
+    // Перемещение по XY
+    ADD_METHOD_TO(
+      MovementController::postPosition,
+      "/position",
+      drogon::Post
     );
     
 
     METHOD_LIST_END
     
-    void getState(const drogon::HttpRequestPtr &req,
+    void postPosition(const drogon::HttpRequestPtr &req,
         std::function<void(const drogon::HttpResponsePtr &)> &&callback);
 };

--- a/server/controllers/StateController.cc
+++ b/server/controllers/StateController.cc
@@ -31,13 +31,23 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
 
     try
     {
-        Json::Value resp;                     // response from server to crm
         Json::Value config = loadConfig();    // конфигурация меха
 
-        //resp["message"] = "State controller is working!!!";
+        // ошибка, если ключ RobotState не найден в конфигурации меха
+        if(!config.isMember("RobotState")){
+            Json::Value errorResponse;
+            errorResponse["status"] = "error";
+            errorResponse["message"] = "RobotState not found in configuration";
 
-        auto response = drogon::HttpResponse::newHttpJsonResponse(config);
-        //auto response = drogon::HttpResponse::newHttpJsonResponse(resp);
+            auto response = drogon::HttpResponse::newHttpJsonResponse(errorResponse);
+            response->setStatusCode(drogon::HttpStatusCode::k404NotFound);
+            callback(response);
+            return;
+        }
+
+        Json::Value robotState = config["RobotState"];
+
+        auto response = drogon::HttpResponse::newHttpJsonResponse(robotState);
         response->setStatusCode(drogon::HttpStatusCode::k200OK);
 
         callback(response);

--- a/server/controllers/StateController.cc
+++ b/server/controllers/StateController.cc
@@ -3,12 +3,8 @@
 #include <iostream>
 #include <fstream>
 
-//check
-//hello
-
-
 Json::Value StateController::loadConfig()
-{
+{   
     Json::Value config;
     std::ifstream configFile("../database/mehConfig.json");
 
@@ -32,7 +28,7 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
     {
         Json::Value config = loadConfig();    // конфигурация меха
 
-        // ошибка, если ключ RobotState не найден в конфигурации меха
+        // ошибка, если RobotState или IntelligenceState не найдены в конфигурации меха
         if(!config.isMember("RobotState") || !config.isMember("IntelligenceState")){
             Json::Value errorResponse;
             errorResponse["status"] = "error";
@@ -44,23 +40,20 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
             return;
         }
 
-        //извлекаем RobotState и "IntelligenceState" 
+        // извлекаем RobotState и IntelligenceState 
         Json::Value robotState = config["RobotState"];
         Json::Value intelligenceState = config["IntelligenceState"];
 
+        // комбинируем 
         Json::Value allState;
         allState["RobotState"] = robotState;
         allState["IntelligenceState"]= intelligenceState;
         
 
         auto responseAllState = drogon::HttpResponse::newHttpJsonResponse(allState);
-        //auto responseIntelligenceState = drogon::HttpResponse::newHttpJsonResponse(intelligenceState);
-
         responseAllState->setStatusCode(drogon::HttpStatusCode::k200OK);
-        //responseIntelligenceState->setStatusCode(drogon::HttpStatusCode::k200OK);
 
         callback(responseAllState);
-        //callback(responseIntelligenceState);
     }
     catch(const std::exception& e)
     {
@@ -71,9 +64,7 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
         response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
 
         callback(response);
-    }
-    
-
+    } 
 }
 
 

--- a/server/controllers/StateController.cc
+++ b/server/controllers/StateController.cc
@@ -11,17 +11,15 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
     try
     {
         // need to get full robot state
-        //for example -> make json answer message = "State controller is working!!!"
+        // for example -> make json answer message = "State controller is working!!!"
 
-        Json::Value resp;
+        Json::Value resp;      // response from server to crm
         resp["message"] = "State controller is working!!!";
 
         auto response = drogon::HttpResponse::newHttpJsonResponse(resp);
         response->setStatusCode(drogon::HttpStatusCode::k200OK);
 
         callback(response);
-
-        //
     }
     catch(const std::exception& e)
     {
@@ -37,4 +35,64 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
 
 }
 
+void StateController::postMessage(const drogon::HttpRequestPtr &req,
+               std::function<void(const drogon::HttpResponsePtr &)> &&callback){
+
+    try
+    {
+        auto requestBody = req->getJsonObject();
+
+        // check the body is not null
+        if (requestBody == nullptr) {
+            jsonBody["status"] = "error";
+            jsonBody["message"] = "Body is required";
+            auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+            response->setStatusCode(HttpStatusCode::k400BadRequest);
+            callback(response);
+            return;
+        }
+
+        // check the body contains the message field
+        if (!requestBody->isMember("message")) {
+            jsonBody["status"] = "error";
+            jsonBody["message"] = "Field `message` is required";
+            auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+            response->setStatusCode(HttpStatusCode::k400BadRequest);
+            callback(response);
+            return;
+        }
+
+        // get the message
+        std::string message = requestBody->get("message", "").asString();
+
+        
+        std::cout << "Received message: " << message << std::endl;
+
+        jsonBody["status"] = "ok";
+        jsonBody["message"] = "Message received: " + message;
+        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+        callback(response);
+
+    catch (const std::exception& e)
+    {
+        jsonBody["status"] = "error";
+        jsonBody["message"] = std::string("Error: ") + e.what();
+        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+        response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
+        callback(response);
+    }
+
+    }
+
+    catch(const std::exception& e)
+    {
+        jsonBody["status"] = "error";
+        jsonBody["message"] = std::string("Error: ") + e.what();
+        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
+        response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
+        callback(response);
+    }
+    
+    
+}
 

--- a/server/controllers/StateController.cc
+++ b/server/controllers/StateController.cc
@@ -37,6 +37,8 @@ void StateController::getState(const drogon::HttpRequestPtr &req,
 
 void StateController::postMessage(const drogon::HttpRequestPtr &req,
                std::function<void(const drogon::HttpResponsePtr &)> &&callback){
+    
+    Json::Value jsonBody;
 
     try
     {
@@ -72,15 +74,6 @@ void StateController::postMessage(const drogon::HttpRequestPtr &req,
         jsonBody["message"] = "Message received: " + message;
         auto response = HttpResponse::newHttpJsonResponse(jsonBody);
         callback(response);
-
-    catch (const std::exception& e)
-    {
-        jsonBody["status"] = "error";
-        jsonBody["message"] = std::string("Error: ") + e.what();
-        auto response = HttpResponse::newHttpJsonResponse(jsonBody);
-        response->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);
-        callback(response);
-    }
 
     }
 

--- a/server/controllers/StateController.h
+++ b/server/controllers/StateController.h
@@ -20,8 +20,8 @@ class StateController : public drogon::HttpController<StateController>
     METHOD_LIST_END
 
     void getState(const drogon::HttpRequestPtr &req,
-        std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // get-запрос
+        std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // функция обработчика get-запроса
     
   private:
-        Json::Value loadConfig();
+        Json::Value loadConfig();                                                // загрузка конфигурации робота
 };

--- a/server/controllers/StateController.h
+++ b/server/controllers/StateController.h
@@ -17,20 +17,10 @@ class StateController : public drogon::HttpController<StateController>
       drogon::Get
     );
 
-    //
-    ADD_METHOD_TO(
-      StateController::postMessage,
-      "/state",
-      drogon::Post
-    );
-
     METHOD_LIST_END
 
     void getState(const drogon::HttpRequestPtr &req,
         std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // get-запрос
-    
-    void postMessage(const drogon::HttpRequestPtr &req,
-               std::function<void(const drogon::HttpResponsePtr &)> &&callback); // post-запрос
     
   private:
         Json::Value loadConfig();

--- a/server/controllers/StateController.h
+++ b/server/controllers/StateController.h
@@ -15,10 +15,18 @@ class StateController : public drogon::HttpController<StateController>
       drogon::Get
     );
 
+    ADD_METHOD_TO(
+      StateController::postMessage,
+      "/message",
+      drogon::Post
+    );
+
     METHOD_LIST_END
 
 
     void getState(const drogon::HttpRequestPtr &req,
-        std::function<void(const drogon::HttpResponsePtr &)> &&callback);
+        std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // get request
     
+    void postMessage(const drogon::HttpRequestPtr &req,
+               std::function<void(const drogon::HttpResponsePtr &)> &&callback); // post request
 };

--- a/server/controllers/StateController.h
+++ b/server/controllers/StateController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <drogon/HttpController.h>
+//#include <drogon/config.h>
 
 using namespace drogon;
 
@@ -9,24 +10,28 @@ class StateController : public drogon::HttpController<StateController>
   public:
     METHOD_LIST_BEGIN
     
+    // состояние робота
     ADD_METHOD_TO(
       StateController::getState,
       "/state",
       drogon::Get
     );
 
+    //
     ADD_METHOD_TO(
       StateController::postMessage,
-      "/message",
+      "/state",
       drogon::Post
     );
 
     METHOD_LIST_END
 
-
     void getState(const drogon::HttpRequestPtr &req,
-        std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // get request
+        std::function<void(const drogon::HttpResponsePtr &)> &&callback);        // get-запрос
     
     void postMessage(const drogon::HttpRequestPtr &req,
-               std::function<void(const drogon::HttpResponsePtr &)> &&callback); // post request
+               std::function<void(const drogon::HttpResponsePtr &)> &&callback); // post-запрос
+    
+  private:
+        Json::Value loadConfig();
 };


### PR DESCRIPTION
Закончил работу над обработчиком get-запросов для  [http://<address:port>/state](url). Теперь с crm можно отправлять по этому адресу запрос и получать информацию о сотсоянии меха и его позиции (RobotState и IntellligenceState). Сервер отправляет данные в формате json. 
Затем привел код в порядок и добавил комментарии :)